### PR TITLE
errorClass element when using row / col

### DIFF
--- a/jquery.validate.unobtrusive.bootstrap.js
+++ b/jquery.validate.unobtrusive.bootstrap.js
@@ -21,7 +21,14 @@
 		var group = element.closest('.form-group');
 		if (group && group.length > 0)
 		{
-			group.addClass('has-error').removeClass('has-success');
+			if (group.hasClass("row"))
+			{
+				element.closest("div[class^='col-']").addClass('has-error')).removeClass('has-success');
+			} 
+			else
+			{
+				group.addClass('has-error').removeClass('has-success');
+			}
 		}
 	}
 
@@ -30,7 +37,14 @@
 		var group = element.closest('.form-group');
 		if (group && group.length > 0)
 		{
-			group.addClass('has-success').removeClass('has-error');
+			if (group.hasClass("row"))
+			{
+				element.closest("div[class^='col-']").addClass('has-success')).removeClass('has-error');
+			} 
+			else
+			{
+				group.addClass('has-success').removeClass('has-error');
+			}
 		}
 	}
 


### PR DESCRIPTION
When placing form elements in a grid, the error class is set on the outer form-control div. If you're form elements span over more columns inside the form-group, the entire form-group (all elements) is highlighted as error.

Example:

```
<div class="row form-group">
    <div class="col-xs-6">
        <label class="control-label" for="TimeStart">TimeStart</label>
        <input class="form-control" id="TimeStart" name="TimeStart" type="text" value="" />
    </div>
    <div class="col-xs-6">
        <label class="control-label" for="Hours">Hours</label>
        <input class="form-control" id="Hours" name="Hours" type="text" value="" />
    </div>
</div>
```

This checks if the form-control element also contains a "row" class. If form elements is placed inside a row element, then it will add the error className to the sub elements which has a className starting with "col-*".
